### PR TITLE
fix: Update emoji extension paths in mkdocs.yaml and add development …

### DIFF
--- a/mkdocs.yaml
+++ b/mkdocs.yaml
@@ -105,8 +105,8 @@ markdown_extensions:
   - md_in_html
   - meta
   - pymdownx.emoji:
-      emoji_index: !!python/name:materialx.emoji.twemoji
-      emoji_generator: !!python/name:materialx.emoji.to_svg
+      emoji_index: !!python/name:material.extensions.emoji.twemoji
+      emoji_generator: !!python/name:material.extensions.emoji.to_svg
       options:
         custom_icons:
           - docs/static/icons
@@ -125,6 +125,7 @@ markdown_extensions:
   - toc
 extra:
   project_name: "Sugar"
+  env: "development"
   team:
     - name: "Active maintainers"
       members:

--- a/mkdocs.yaml
+++ b/mkdocs.yaml
@@ -125,7 +125,6 @@ markdown_extensions:
   - toc
 extra:
   project_name: "Sugar"
-  env: "development"
   team:
     - name: "Active maintainers"
       members:


### PR DESCRIPTION
Fixed `Macro Rendering Error
UndefinedError: 'env' is undefined`  issue in sugar's mkdocs documentations github page


## How to test these changes

```
mkdocs serve 
```
## About this PR:
- Added an `env` variable to your extra section in mkdocs.yaml
- mitigated deprecation warning for `materialx.emoji.twemoji` and `materialx.emoji.to_svg` in mkdocs conf file 