### PR TITLE
feat: Add support for positional only

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -114,6 +114,7 @@ jobs:
       - name: Install dependencies
         run: |
           poetry install --verbose
+          poetry install --verbose --extras tui
 
       - name: Run style checks
         run: makim tests.linter

--- a/src/sugar/cli.py
+++ b/src/sugar/cli.py
@@ -217,10 +217,17 @@ def create_args_string(args: dict[str, dict[str, str]]) -> str:
     """Return a string for arguments for a function for typer."""
     args_rendered = []
 
-    arg_template = (
+    arg_template_flag = (
         '{arg_name}: Optional[{arg_type}] = typer.Option('
         '{default_value}, '
         '"--{name_flag}", '
+        'help="{help_text}"'
+        ')'
+    )
+
+    arg_template_positional = (
+        '{arg_name}: Optional[{arg_type}] = typer.Argument('
+        '{default_value}, '
         'help="{help_text}"'
         ')'
     )
@@ -230,6 +237,7 @@ def create_args_string(args: dict[str, dict[str, str]]) -> str:
         arg_type = normalize_string_type(spec.get('type', 'str'))
         help_text = spec.get('help', '')
         default_value = 'None'
+        is_positional_only = spec.get('positional_only', False)
 
         if not spec.get('required', False) and not spec.get(
             'interactive', False
@@ -237,7 +245,13 @@ def create_args_string(args: dict[str, dict[str, str]]) -> str:
             default_value = spec.get('default', '')
             default_value = get_default_value_str(arg_type, default_value)
 
-        arg_str = arg_template.format(
+        selected_template = (
+            arg_template_flag
+            if is_positional_only == 'False'
+            else arg_template_positional
+        )
+
+        arg_str = selected_template.format(
             **{
                 'arg_name': name_clean,
                 'arg_type': arg_type,

--- a/src/sugar/docs.py
+++ b/src/sugar/docs.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import functools
 import inspect
 
+from inspect import _ParameterKind
 from typing import Any, Callable, Dict, Protocol, TypeVar, Union, cast
 
 from typing_extensions import TypeAlias
@@ -70,6 +71,11 @@ def docparams(
                 param_info['help'] = param_docs[name]
             if param.default != inspect.Parameter.empty:
                 param_info['default'] = param.default
+
+            param_info['positional_only'] = repr(
+                param.kind == _ParameterKind.POSITIONAL_ONLY
+            )
+
             parameters[name] = param_info
 
         # Build parameter documentation

--- a/src/sugar/extensions/compose.py
+++ b/src/sugar/extensions/compose.py
@@ -58,6 +58,7 @@ class SugarCompose(SugarBase):
     def _cmd_attach(
         self,
         service: str = '',
+        /,
         options: str = '',
     ) -> None:
         """

--- a/src/sugar/extensions/stats.py
+++ b/src/sugar/extensions/stats.py
@@ -198,7 +198,7 @@ class StatsPlot:
             )
 
 
-class StatsPlotWidget(Widget):  # type: ignore
+class StatsPlotWidget(Widget):
     """Plot Docker Stats Widget."""
 
     content: Reactive[str] = Reactive('')
@@ -243,7 +243,7 @@ class StatsPlotWidget(Widget):  # type: ignore
         return Text.from_ansi(self.content)
 
 
-class StatsPlotApp(App[str]):  # type: ignore
+class StatsPlotApp(App[str]):
     """StatsPlotApp app class."""
 
     TITLE = 'Sugar Containers Stats'

--- a/tests/test_docs.py
+++ b/tests/test_docs.py
@@ -23,11 +23,16 @@ def test_docparams() -> None:
     expected = {
         'title': 'Run a nice function.',
         'parameters': {
-            'arg1': {'type': 'str', 'help': 'this is the arg 1'},
+            'arg1': {
+                'type': 'str',
+                'help': 'this is the arg 1',
+                'positional_only': 'False',
+            },
             'arg2': {
                 'type': 'str',
                 'help': 'this is the arg 2',
                 'default': '1',
+                'positional_only': 'False',
             },
         },
     }


### PR DESCRIPTION
Currently, all the parameters are added as keyword arguments, for example `--services`, `--all`,  `--options`, etc.

This PR aims to add support for positional only parameters, for example:

```python

    @docparams(doc_common_service)
    def _cmd_attach(
        self,
        service: str = '',
        options: str = '',
    ) -> None:
        """
        Attach to a service's running container.

        Attach local standard input, output, and error streams to a service's
        running container.

        Note: This is an experimental feature.
        """
        services_names = self._get_service_name(service)
        options_args = self._get_list_args(options)
        self._call_backend_app(
            'attach', services=services_names, options_args=options_args
        )

```

This is the current code with keyword argument, and this is the result:

```bash

01:39 $ sugar compose attach --help
                                                                                                   
 Usage: sugar compose attach [OPTIONS]                                                             
                                                                                                   
 Attach to a service's running container.                                                          
 Attach local standard input, output, and error streams to a service's running container.          
 Note: This is an experimental feature.                                                            
                                                                                                   
╭─ Options ───────────────────────────────────────────────────────────────────────────────────────╮
│ --service        TEXT  Set the service for the container call.                                  │
│ --options        TEXT  Specify the options for the backend command. E.g.: `--options -d`.       │
│ --help                 Show this message and exit.                                              │
╰─────────────────────────────────────────────────────────────────────────────────────────────────╯

```

if we change it to positional only, the code would look like:

```python

    @docparams(doc_common_service)
    def _cmd_attach(
        self,
        service: str = '',
        / ,
        options: str = '',
    ) -> None:
        """
        Attach to a service's running container.

        Attach local standard input, output, and error streams to a service's
        running container.

        Note: This is an experimental feature.
        """
        services_names = self._get_service_name(service)
        options_args = self._get_list_args(options)
        self._call_backend_app(
            'attach', services=services_names, options_args=options_args
        )

```


and the result would look like this:

```bash
$ sugar compose attach --help
                                                                                                   
 Usage: sugar compose attach [OPTIONS] [SERVICE]                                                   
                                                                                                   
 Attach to a service's running container.                                                          
 Attach local standard input, output, and error streams to a service's running container.          
 Note: This is an experimental feature.                                                            
                                                                                                   
╭─ Arguments ─────────────────────────────────────────────────────────────────────────────────────╮
│   service      [SERVICE]  Set the service for the container call.                               │
╰─────────────────────────────────────────────────────────────────────────────────────────────────╯
╭─ Options ───────────────────────────────────────────────────────────────────────────────────────╮
│ --options        TEXT  Specify the options for the backend command. E.g.: `--options -d`.       │
│ --help                 Show this message and exit.                                              │
╰─────────────────────────────────────────────────────────────────────────────────────────────────╯


```