### PR TITLE
bug: fixed `sugar compose restart`

### DIFF
--- a/src/sugar/extensions/compose.py
+++ b/src/sugar/extensions/compose.py
@@ -312,12 +312,9 @@ class SugarCompose(SugarBase):
         all: bool = False,
         options: str = '',
     ) -> None:
-        """Restart service containers."""
-        services_names = self._get_services_names(services=services, all=all)
-        options_args = self._get_list_args(options)
-        self._call_backend_app(
-            'restart', services=services_names, options_args=options_args
-        )
+        """Restart services (compose stop + up)."""
+        self._cmd_stop(services=services, all=all)
+        self._cmd_start(services=services, all=all, options=options)
 
     @docparams(doc_common_services)
     def _cmd_rm(


### PR DESCRIPTION
## Pull Request description
After investigation and testing, it has been confirmed that the `sugar compose restart` command is functioning as expected. Users are able to successfully start services without encountering errors.


Resolves: #159

## How to test these changes

Run `sugar compose restart`


This PR is a:

- [x] bug-fix
- [ ] new feature
- [x] maintenance

About this PR:

- [ ] it includes tests.
- [x] the tests are executed on CI.
- [ ] the tests generate log file(s) (path).
- [ ] pre-commit hooks were executed locally.
- [ ] this PR requires a project documentation update.

Author's checklist:

- [x] I have reviewed the changes and it contains no misspelling.
- [ ] The code is well commented, especially in the parts that contain more
      complexity.
- [ ] New and old tests passed locally.


```
## Reviewer's Checklist

- [ ] I managed to reproduce the problem locally from the `main` branch
- [ ] I managed to test the new changes locally
- [ ] I confirm that the issues mentioned were fixed/resolved .
```
