### PR TITLE
bug: fixing version flag handling in CLI

### DIFF
--- a/src/sugar/cli.py
+++ b/src/sugar/cli.py
@@ -95,7 +95,7 @@ def main(
         '--version',
         '-v',
         is_flag=True,
-        callback=version_callback,  # Connecting to the callback
+        callback=version_callback,
         is_eager=True,
         help='Show the version of sugar.',
     ),

--- a/src/sugar/cli.py
+++ b/src/sugar/cli.py
@@ -70,9 +70,11 @@ def _check_sugar_file(file_path: str = '.sugar.yaml') -> bool:
     return Path(file_path).exists()
 
 
-def version_callback() -> None:
-    """Print the Sugar version."""
-    SugarLogs.print_info(f'Sugar version: {__version__}')
+def version_callback(value: bool) -> None:
+    """Print the Sugar version and exit if flag is set."""
+    if value:
+        SugarLogs.print_info(f'Sugar version: {__version__}')
+        raise typer.Exit()
 
 
 @app.callback(invoke_without_command=True)
@@ -89,10 +91,11 @@ def main(
         help='Set the profile of services for running the sugar command.',
     ),
     version: bool = Option(
-        None,
+        False,  # Changed from None
         '--version',
         '-v',
         is_flag=True,
+        callback=version_callback,  # Connecting to the callback
         is_eager=True,
         help='Show the version of sugar.',
     ),

--- a/src/sugar/cli.py
+++ b/src/sugar/cli.py
@@ -91,7 +91,7 @@ def main(
         help='Set the profile of services for running the sugar command.',
     ),
     version: bool = Option(
-        False,  # Changed from None
+        False,
         '--version',
         '-v',
         is_flag=True,


### PR DESCRIPTION
### What this PR does?

Solve #168 

This PR refactors the handling of the --version flag in the CLI by updating the version_callback function and modifying the Option configuration.

### Changes Introduced

- Updated version_callback to accept a boolean flag (value: bool) instead of being parameterless.
- Ensured that version_callback raises typer.Exit() to exit the CLI properly after displaying the version.
- Changed the default value of version in Option from None to False for better consistency.
- Linked the version_callback to the version option to trigger version printing correctly.

## Pull Request checklists

This PR is a:

- [x] bug-fix
- [ ] new feature
- [ ] maintenance

About this PR:

- [ ] it includes tests.
- [ ] the tests are executed on CI.
- [ ] the tests generate log file(s) (path).
- [ ] pre-commit hooks were executed locally.
- [ ] this PR requires a project documentation update.

Author's checklist:

- [x] I have reviewed the changes and it contains no misspelling.
- [x] The code is well commented, especially in the parts that contain more
      complexity.
- [ ] New and old tests passed locally.

<!-- Add any screenshot that helps to show the changes proposed -->
Before:
<img width="366" alt="Screenshot 2025-03-11 at 4 26 34 PM" src="https://github.com/user-attachments/assets/7e10ac23-093c-4383-8c2f-db770e697e4f" />

After:
<img width="369" alt="Screenshot 2025-03-11 at 4 26 44 PM" src="https://github.com/user-attachments/assets/f6d31cdd-08c5-42b6-80c0-8490a0a12867" />
