### PR TITLE
Refactor: Introduce `_load_backend` Abstract Method for Improved Extensibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ These commands are available in the main profile/plugin, so you don't need to
 specify any extra parameter to access them.
 
 For extra commands, we are gathering them into a profile/plugin called `ext`, so
-you can access them using something like: `sugar ext restart`.
+you can access them using something like: `sugar compose-ext restart`.
 
 The current available **ext** commands are:
 
@@ -117,13 +117,14 @@ Some examples of how to use it:
 - build all services (ignore default) for profile1:
   `sugar build --profile profile1 --all`
 
-- start the default services for profile1: `sugar ext start --profile profile1`
+- start the default services for profile1:
+  `sugar compose-ext start --profile profile1`
 
 - restart all services (ignore defaults) for profile1:
-  `sugar ext restart --profile profile1 --all`
+  `sugar compose-ext restart --profile profile1 --all`
 
 - restart service1 and service2 for profile1:
-  `sugar ext restart --profile profile1 --services service1,service2`
+  `sugar compose-ext restart --profile profile1 --services service1,service2`
 
 **NOTE**: If you use: `default: profile: ${{ env.ENV }}`, you don't need to give
 `--profile <PROFILE_NAME>`, except if you want a different profile than the

--- a/src/sugar/extensions/base.py
+++ b/src/sugar/extensions/base.py
@@ -108,7 +108,7 @@ class SugarBase(ABC):
     def _load_backend(self) -> None:
         """
         Initialize the backend application and its arguments.
-        
+
         This method must be implemented by subclasses to set:
         - self.backend_app
         - self.backend_args

--- a/src/sugar/extensions/compose.py
+++ b/src/sugar/extensions/compose.py
@@ -69,9 +69,9 @@ class SugarCompose(SugarBase):
 
         self.backend_app = sh.docker
         self.backend_args.append(backend_cmd)
-        
+
         self._load_compose_args()
-        
+
     def _load_compose_args(self) -> None:
         self._filter_service_profile()
 

--- a/src/sugar/extensions/compose.py
+++ b/src/sugar/extensions/compose.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import sh
+
 from sugar.docs import docparams
 from sugar.extensions.base import SugarBase
 from sugar.logs import SugarError, SugarLogs
@@ -53,6 +55,52 @@ doc_common_services_no_options = {
 
 class SugarCompose(SugarBase):
     """SugarCompose provides the docker compose commands."""
+
+    def _load_backend(self) -> None:
+        backend_cmd = self.config.get('backend', '')
+        supported_backends = ['compose']
+
+        if backend_cmd not in supported_backends:
+            SugarLogs.raise_error(
+                f'"{self.config["backend"]}" not supported yet.'
+                f' Supported backends are: {", ".join(supported_backends)}.',
+                SugarError.SUGAR_COMPOSE_APP_NOT_SUPPORTED,
+            )
+
+        self.backend_app = sh.docker
+        self.backend_args.append(backend_cmd)
+        
+        self._load_compose_args()
+        
+    def _load_compose_args(self) -> None:
+        self._filter_service_profile()
+
+        if self.service_profile.get('env-file'):
+            self.backend_args.extend(
+                ['--env-file', self.service_profile['env-file']]
+            )
+
+        config_path = []
+        backend_path_arg = self.service_profile['config-path']
+        if isinstance(backend_path_arg, str):
+            config_path.append(backend_path_arg)
+        elif isinstance(backend_path_arg, list):
+            config_path.extend(backend_path_arg)
+        else:
+            SugarLogs.raise_error(
+                'The attribute config-path` just supports the data '
+                f'types `string` or `list`, {type(backend_path_arg)} '
+                'received.',
+                SugarError.SUGAR_INVALID_CONFIGURATION,
+            )
+
+        for p in config_path:
+            self.backend_args.extend(['--file', p])
+
+        if self.service_profile.get('project-name'):
+            self.backend_args.extend(
+                ['--project-name', self.service_profile['project-name']]
+            )
 
     @docparams(doc_common_service)
     def _cmd_attach(


### PR DESCRIPTION
### What this PR does?

This PR enhances `SugarBase` by introducing `_load_backend()` as an abstract method, ensuring that each subclass implements its own backend initialization logic.

Solves #151 

### Key Changes:

- Added `_load_backend()` as an `@abstractmethod` in `SugarBase`, enforcing that all subclasses define backend initialization.
- Removed `_load_backend_app()` and `_load_backend_args()` from `SugarBase`, as their functionality is now encapsulated in `_load_backend()`.
- Implemented `_load_backend()` in `SugarCompose`, which initializes Docker Compose as the backend and sets up its arguments.
- Added `_load_compose_args()` to handle Docker Compose–specific argument parsing.

This PR is a:

- [ ] bug-fix
- [ ] new feature
- [x] maintenance

Author's checklist:

- [x] I have reviewed the changes and it contains no misspelling.
