### PR TITLE
[feat]: add support for multiple `.env` files

### DIFF
--- a/src/sugar/extensions/base.py
+++ b/src/sugar/extensions/base.py
@@ -318,10 +318,13 @@ class SugarBase:
     def _load_backend_args(self) -> None:
         self._filter_service_profile()
 
-        if self.service_profile.get('env-file'):
-            self.backend_args.extend(
-                ['--env-file', self.service_profile['env-file']]
-            )
+        env_files = self.service_profile.get('env-file')
+        if env_files:
+            if isinstance(env_files, str):
+                env_files = [env_files]
+
+            for env_file in filter(None, env_files):
+                self.backend_args.extend(['--env-file', env_file])
 
         config_path = []
         backend_path_arg = self.service_profile['config-path']

--- a/src/sugar/extensions/base.py
+++ b/src/sugar/extensions/base.py
@@ -360,22 +360,31 @@ class SugarBase:
     def _load_env(self) -> None:
         self.env = dict(os.environ)
 
-        env_file = self.config.get('env-file', '')
+        env_files = self.config.get('env-file', '')
 
-        if not env_file:
+        if isinstance(env_files, str):
+            env_files = [env_files] if env_files else []
+
+        if not env_files:
             return
 
-        if not env_file.startswith('/'):
-            # use .sugar file as reference for the working
-            # directory for the .env file
-            env_file = str(Path(self.file).parent / env_file)
+        for env_file in env_files:
+            if not env_file:
+                continue
 
-        if not Path(env_file).exists():
-            SugarLogs.raise_error(
-                'The given env-file was not found.',
-                SugarError.SUGAR_INVALID_CONFIGURATION,
-            )
-        self.env.update(dotenv.dotenv_values(env_file))  # type: ignore
+            env_file_path = env_file
+
+            if not env_file.startswith('/'):
+                # use .sugar file as reference for the working
+                # directory for the .env file
+                env_file_path = str(Path(self.file).parent / env_file)
+
+            if not Path(env_file_path).exists():
+                SugarLogs.raise_error(
+                    f'Env file was not found: {env_file_path}',
+                    SugarError.SUGAR_INVALID_CONFIGURATION,
+                )
+            self.env.update(dotenv.dotenv_values(env_file_path))  # type: ignore
 
     def _get_list_args(self, args: str) -> list[str]:
         """Return a list with the name of the service if any."""

--- a/src/sugar/schema.json
+++ b/src/sugar/schema.json
@@ -8,7 +8,17 @@
       "enum": ["compose"]
     },
     "env-file": {
-      "type": "string"
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      ]
     },
     "defaults": {
       "type": "object",
@@ -109,7 +119,17 @@
               ]
             },
             "env-file": {
-              "type": "string"
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                }
+              ]
             },
             "services": {
               "type": "object",


### PR DESCRIPTION
### What this PR does?

Solves #88 

Updated `_load_env`, `_load_backend_args` and `schema.json` to support multiple environment files.

## Potential Improvement

We could use `itertools.chain` for efficiency, also the current approach makes multiple `extend` calls instead of one. However, for small applications, the performance impact is negligible. We can refactor this later if needed.

Let me know if you want to go ahead with the `itertools` optimization now or keep it for a future commit.

## How to test these changes

`--env-file .env --env-file .env2` works

## Pull Request checklists

This PR is a:

- [ ] bug-fix
- [x] new feature
- [ ] maintenance

About this PR:

- [ ] it includes tests.
- [ ] the tests are executed on CI.
- [ ] the tests generate log file(s) (path).
- [ ] pre-commit hooks were executed locally.
- [ ] this PR requires a project documentation update.

Author's checklist:

- [x] I have reviewed the changes and it contains no misspelling.
- [x] The code is well commented, especially in the parts that contain more
      complexity.
- [x] New and old tests passed locally.