### PR TITLE
[enhancement]: Change services/default property from string to array(list) format

### DIFF
--- a/.sugar.yaml
+++ b/.sugar.yaml
@@ -9,7 +9,9 @@ profiles:
     config-path: tests/containers/profile1/compose.yaml
     env-file: .env
     services:
-      default: service1-1,service1-3
+      default:
+        - service1-1
+        - service1-3
       available:
         - name: service1-1
         - name: service1-2

--- a/README.md
+++ b/README.md
@@ -91,7 +91,9 @@ profiles:
       - containers/tests/profile1/compose.yaml
     env-file: .env
     services:
-      default: service1,service3
+      default:
+        - service1
+        - service3
       available:
         - name: service1
         - name: service2

--- a/docs/index.md
+++ b/docs/index.md
@@ -114,8 +114,7 @@ Some examples of how to use it:
 - build all services (ignore default) for group1:
   `sugar build --group group1 --all`
 
-- start the default services for group1:
-  `sugar compose-ext start --group group`
+- start the default services for group1: `sugar compose-ext start --group group`
 
 - restart all services (ignore defaults) for group1:
   `sugar compose-ext restart --group group1 --all`

--- a/docs/index.md
+++ b/docs/index.md
@@ -62,7 +62,7 @@ These commands are available in the main profile/plugin, so you don't need to
 specify any extra parameter to access them.
 
 For extra commands, we are gathering them into a profile/plugin called `ext`, so
-you can access them using something like: `sugar ext restart`.
+you can access them using something like: `sugar compose-ext restart`.
 
 The current available **ext** commands are:
 
@@ -76,7 +76,7 @@ project. This is an example of a configuration file:
 
 ```yaml
 backend: compose
-default:
+defaults:
   group:  {% raw %} ${{ env.ENV }} {% endraw %}
 groups:
   group1:
@@ -114,13 +114,14 @@ Some examples of how to use it:
 - build all services (ignore default) for group1:
   `sugar build --group group1 --all`
 
-- start the default services for group1: `sugar ext start --group group1`
+- start the default services for group1:
+  `sugar compose-ext start --group group`
 
 - restart all services (ignore defaults) for group1:
-  `sugar ext restart --group group1 --all`
+  `sugar compose-ext restart --group group1 --all`
 
 - restart service1 and service2 for group1:
-  `sugar ext restart --group group1 --services service1,service2`
+  `sugar compose-ext restart --group group1 --services service1,service2`
 
 **NOTE**: If you use: `default: group: {% raw %} ${{ env.ENV }} {% endraw %}`,
 you don't need to give `--group <GROUP_NAME>`, except if you want a different

--- a/src/sugar/extensions/base.py
+++ b/src/sugar/extensions/base.py
@@ -222,8 +222,8 @@ class SugarBase:
                 'config-path': services.get('config-path'),
                 'env-file': services.get('env-file'),
                 'services': {
-                    'default': services.get('default'),
-                    'available': services.get('available'),
+                    'default': services.get('default', []),
+                    'available': services.get('available', []),
                 },
             }
         }
@@ -264,9 +264,7 @@ class SugarBase:
                             'available', []
                         )
                     ]
-                    profile_data['services']['default'] = ','.join(
-                        default_services
-                    )
+                    profile_data['services']['default'] = default_services
                 self.service_profile = profile_data
                 return
 
@@ -398,7 +396,7 @@ class SugarBase:
 
         services_config = self.service_profile['services']
         service_names: list[str] = []
-        services_default = services_config.get('default', '')
+        services_default = services_config.get('default', [])
 
         if _arg_all:
             service_names = [
@@ -410,7 +408,7 @@ class SugarBase:
         elif _arg_services:
             service_names = _arg_services.split(',')
         elif services_default:
-            service_names = services_default.split(',')
+            service_names = services_default
         else:
             SugarLogs.raise_error(
                 'If you want to execute the operation for all services, '

--- a/src/sugar/schema.json
+++ b/src/sugar/schema.json
@@ -115,7 +115,10 @@
               "type": "object",
               "properties": {
                 "default": {
-                  "type": "string"
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
                 },
                 "available": {
                   "type": "array",
@@ -151,7 +154,10 @@
           "type": "string"
         },
         "default": {
-          "type": "string"
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
         },
         "available": {
           "type": "array",

--- a/tests/containers/.hooks.sugar.yaml
+++ b/tests/containers/.hooks.sugar.yaml
@@ -27,7 +27,9 @@ hooks:
 services:
   project-name: project1
   config-path: profile1/compose.yaml
-  default: service1-1,service1-3
+  default:
+    - service1-1
+    - service1-3
   available:
     - name: service1-1
     - name: service1-2

--- a/tests/containers/.multiple-env.sugar.yaml
+++ b/tests/containers/.multiple-env.sugar.yaml
@@ -12,7 +12,9 @@ profiles:
       - .env
       - .env2
     services:
-      default: service1-1,service1-3
+      default:
+        - service1-1
+        - service1-3
       available:
         - name: service1-1
         - name: service1-2

--- a/tests/containers/.services.sugar.yaml
+++ b/tests/containers/.services.sugar.yaml
@@ -4,7 +4,9 @@ defaults:
 services:
   project-name: project1
   config-path: tests/containers/profile1/compose.yaml
-  default: service1-1,service1-3
+  default:
+    - service1-1
+    - service1-3
   available:
     - name: service1-1
     - name: service1-2


### PR DESCRIPTION
### What this PR does?

Solves #153 

Reopening this PR since the previous one (https://github.com/osl-incubator/sugar/pull/172) went stale.

## Changes

Modified the `schema.json` file to change the default property from `"type": "string"` to an array type

```json
"default": {
  "type": "array",
  "items": {
    "type": "string"
  }
}
```

## Alternate approach

The alternate approach would be to:

Update the `schema.json` to validate the new list format for "default" services and add conversion logic at the config file interface points.

This would minimize changes to the codebase while achieving the desired YAML format update and the backend continues to work with comma-separated strings internally, but users interact with the list format in their `.sugar.yaml` files.

## Pull Request checklists

This PR is a:

- [ ] bug-fix
- [ ] new feature
- [x] maintenance

About this PR:

- [ ] it includes tests.
- [x] the tests are executed on CI.
- [ ] the tests generate log file(s) (path).
- [x] pre-commit hooks were executed locally.
- [x] this PR requires a project documentation update.

Author's checklist:

- [x] I have reviewed the changes and it contains no misspelling.
- [ ] The code is well commented, especially in the parts that contain more
      complexity.
- [x] New and old tests passed locally.
