### PR TITLE
feat(apple-container): implement Apple Container extension for macOS

### DIFF
--- a/src/sugar/extensions/apple_container.py
+++ b/src/sugar/extensions/apple_container.py
@@ -1,0 +1,244 @@
+"""Apple Container Extension for Sugar.
+
+Manages Apple Container runtime on macOS M-series chips.
+Provides interface compatible with docker-compose workflow.
+"""
+
+import subprocess
+import sys
+
+from typing import Any, Dict, List, Optional
+
+
+class AppleContainerExtension:
+    """Apple Container extension for Sugar.
+
+    Provides a unified interface for managing containers using
+    Apple's container runtime on M-series Macs.
+    """
+
+    STANDARD_COMMANDS: List[str] = [
+        'build',
+        'create',
+        'down',
+        'exec',
+        'images',
+        'kill',
+        'logs',
+        'pause',
+        'ps',
+        'pull',
+        'push',
+        'restart',
+        'rm',
+        'run',
+        'start',
+        'stop',
+        'top',
+        'unpause',
+        'up',
+        'version',
+    ]
+
+    EXPERIMENTAL_COMMANDS: List[str] = [
+        'attach',
+        'cp',
+        'ls',
+        'scale',
+        'wait',
+        'watch',
+    ]
+
+    def __init__(
+        self,
+        config: Dict[str, Any],
+        use_dummy: bool = False,
+        state_file: Optional[str] = None,
+    ) -> None:
+        """Initialize Apple Container extension.
+
+        Args:
+            config: Configuration dict from .sugar.yaml
+            use_dummy: Use dummy interface for testing
+            state_file: Path to state file for dummy interface
+        """
+        self.config = config
+        self.use_dummy = use_dummy
+        self.state_file = state_file or 'apple_container_state.json'
+
+        if use_dummy:
+            from sugar.extensions.apple_container_dummy import (
+                AppleContainerDummy,
+            )
+
+            self.runtime: Any = AppleContainerDummy(self.state_file)
+        else:
+            self.runtime = None
+
+    def _execute_command(
+        self,
+        command: str,
+        services: Optional[List[str]] = None,
+        extra_args: Optional[List[str]] = None,
+    ) -> int:
+        """Execute a command through the container runtime.
+
+        Args:
+            command: Command name (e.g., 'build', 'up', 'down')
+            services: List of service names (optional)
+            extra_args: Extra command arguments (optional)
+
+        Returns
+        -------
+            Return code (0 for success)
+        """
+        if self.use_dummy:
+            return self._dummy_execute(command, services)
+        else:
+            return self._real_execute(command, services, extra_args)
+
+    def _dummy_execute(
+        self, command: str, services: Optional[List[str]] = None
+    ) -> int:
+        """Execute command using dummy interface."""
+        try:
+            if command == 'create' and services:
+                for service in services:
+                    self.runtime.create(service, f'image-{service}')
+            elif command == 'start' and services:
+                for service in services:
+                    self.runtime.start(service)
+            elif command == 'stop' and services:
+                for service in services:
+                    self.runtime.stop(service)
+            elif command == 'ps':
+                containers = self.runtime.get_containers()
+                if containers:
+                    print('CONTAINER ID\tIMAGE\t\tSTATUS')
+                    for name, info in containers.items():
+                        print(
+                            f'{name[:12]}\t{info["image"]}\t{info["status"]}'
+                        )
+            elif command == 'down':
+                for name in list(self.runtime.get_containers().keys()):
+                    self.runtime.remove(name)
+            return 0
+        except Exception as e:
+            print(f'Error executing {command}: {e}', file=sys.stderr)
+            return 1
+
+    def _real_execute(
+        self,
+        command: str,
+        services: Optional[List[str]] = None,
+        extra_args: Optional[List[str]] = None,
+    ) -> int:
+        """Execute command using real Apple Container CLI."""
+        args: List[str] = ['container', command]
+
+        if services:
+            args.extend(services)
+
+        if extra_args:
+            args.extend(extra_args)
+
+        try:
+            result = subprocess.run(args, check=False)  # nosec
+            return result.returncode
+        except FileNotFoundError:
+            print(
+                "Error: 'container' command not found. "
+                'Please ensure Apple Container is installed.',
+                file=sys.stderr,
+            )
+            return 1
+        except Exception as e:
+            print(f'Error executing {command}: {e}', file=sys.stderr)
+            return 1
+
+    def build(self, services: Optional[List[str]] = None) -> int:
+        """Build services."""
+        return self._execute_command('build', services)
+
+    def config(self, services: Optional[List[str]] = None) -> int:
+        """Show compose configuration."""
+        return self._execute_command('config', services)
+
+    def create(self, services: Optional[List[str]] = None) -> int:
+        """Create services."""
+        return self._execute_command('create', services)
+
+    def down(self, services: Optional[List[str]] = None) -> int:
+        """Stop and remove containers."""
+        return self._execute_command('down', services)
+
+    def exec(self, service: str, command: str) -> int:
+        """Execute command in service."""
+        return self._execute_command('exec', [service], [command])
+
+    def images(self, services: Optional[List[str]] = None) -> int:
+        """List images."""
+        return self._execute_command('images', services)
+
+    def kill(self, services: Optional[List[str]] = None) -> int:
+        """Kill containers."""
+        return self._execute_command('kill', services)
+
+    def logs(self, services: Optional[List[str]] = None) -> int:
+        """View logs."""
+        return self._execute_command('logs', services)
+
+    def pause(self, services: Optional[List[str]] = None) -> int:
+        """Pause services."""
+        return self._execute_command('pause', services)
+
+    def ps(self, services: Optional[List[str]] = None) -> int:
+        """List containers."""
+        return self._execute_command('ps', services)
+
+    def pull(self, services: Optional[List[str]] = None) -> int:
+        """Pull images."""
+        return self._execute_command('pull', services)
+
+    def push(self, services: Optional[List[str]] = None) -> int:
+        """Push images."""
+        return self._execute_command('push', services)
+
+    def restart(self, services: Optional[List[str]] = None) -> int:
+        """Restart services."""
+        result = self._execute_command('stop', services)
+        if result != 0:
+            return result
+        return self._execute_command('start', services)
+
+    def rm(self, services: Optional[List[str]] = None) -> int:
+        """Remove containers."""
+        return self._execute_command('rm', services)
+
+    def run(self, services: Optional[List[str]] = None) -> int:
+        """Run one-off command."""
+        return self._execute_command('run', services)
+
+    def start(self, services: Optional[List[str]] = None) -> int:
+        """Start services."""
+        return self._execute_command('start', services)
+
+    def stop(self, services: Optional[List[str]] = None) -> int:
+        """Stop services."""
+        return self._execute_command('stop', services)
+
+    def top(self, services: Optional[List[str]] = None) -> int:
+        """Display running processes."""
+        return self._execute_command('top', services)
+
+    def unpause(self, services: Optional[List[str]] = None) -> int:
+        """Unpause services."""
+        return self._execute_command('unpause', services)
+
+    def up(self, services: Optional[List[str]] = None) -> int:
+        """Create and start containers."""
+        return self._execute_command('up', services)
+
+    def version(self) -> int:
+        """Show version."""
+        return self._execute_command('version')

--- a/src/sugar/extensions/apple_container_dummy.py
+++ b/src/sugar/extensions/apple_container_dummy.py
@@ -1,0 +1,162 @@
+"""Apple Container CLI Dummy Interface.
+
+Simulates Apple Container CLI for testing on non-Mac systems.
+"""
+
+import json
+import os
+
+from datetime import datetime
+from typing import Any, Dict, Optional
+
+
+class AppleContainerDummy:
+    """Dummy interface that simulates Apple Container CLI.
+
+    Stores state in a JSON file for testing on Linux/CI systems.
+    This allows development and testing without requiring macOS hardware.
+    """
+
+    def __init__(self, state_file: str = 'apple_container_state.json') -> None:
+        """Initialize the dummy Apple Container interface.
+
+        Args:
+            state_file: Path to JSON file for storing state
+        """
+        self.state_file = state_file
+        self.state = self._load_state()
+
+    def _load_state(self) -> Dict[str, Any]:
+        """Load state from JSON file or initialize empty state."""
+        if os.path.exists(self.state_file):
+            try:
+                with open(self.state_file) as f:
+                    return json.load(f)
+            except (json.JSONDecodeError, IOError):
+                return self._empty_state()
+        return self._empty_state()
+
+    @staticmethod
+    def _empty_state() -> Dict[str, Any]:
+        """Return empty state structure."""
+        return {'containers': {}, 'images': {}, 'networks': {}, 'volumes': {}}
+
+    def _save_state(self) -> None:
+        """Save current state to JSON file."""
+        try:
+            with open(self.state_file, 'w') as f:
+                json.dump(self.state, f, indent=2)
+        except IOError as e:
+            raise RuntimeError(f'Failed to save state: {e}')
+
+    def create(self, name: str, image: str, **kwargs: Any) -> bool:
+        """Create a container.
+
+        Args:
+            name: Container name
+            image: Image name
+            **kwargs: Additional container configuration
+
+        Returns
+        -------
+            True if created successfully, False if already exists
+        """
+        if name in self.state['containers']:
+            return False
+
+        self.state['containers'][name] = {
+            'image': image,
+            'status': 'created',
+            'created_at': datetime.now().isoformat(),
+            'config': kwargs,
+        }
+        self._save_state()
+        return True
+
+    def start(self, name: str) -> bool:
+        """Start a container.
+
+        Args:
+            name: Container name
+
+        Returns
+        -------
+            True if started successfully, False if not found
+        """
+        if name not in self.state['containers']:
+            return False
+
+        self.state['containers'][name]['status'] = 'running'
+        self.state['containers'][name]['started_at'] = (
+            datetime.now().isoformat()
+        )
+        self._save_state()
+        return True
+
+    def stop(self, name: str) -> bool:
+        """Stop a container.
+
+        Args:
+            name: Container name
+
+        Returns
+        -------
+            True if stopped successfully, False if not found
+        """
+        if name not in self.state['containers']:
+            return False
+
+        self.state['containers'][name]['status'] = 'stopped'
+        self.state['containers'][name]['stopped_at'] = (
+            datetime.now().isoformat()
+        )
+        self._save_state()
+        return True
+
+    def remove(self, name: str) -> bool:
+        """Remove a container.
+
+        Args:
+            name: Container name
+
+        Returns
+        -------
+            True if removed successfully, False if not found
+        """
+        if name not in self.state['containers']:
+            return False
+
+        del self.state['containers'][name]
+        self._save_state()
+        return True
+
+    def pause(self, name: str) -> bool:
+        """Pause a container."""
+        if name not in self.state['containers']:
+            return False
+
+        self.state['containers'][name]['status'] = 'paused'
+        self._save_state()
+        return True
+
+    def unpause(self, name: str) -> bool:
+        """Unpause a container."""
+        if name not in self.state['containers']:
+            return False
+
+        self.state['containers'][name]['status'] = 'running'
+        self._save_state()
+        return True
+
+    def get_containers(self) -> Dict[str, Any]:
+        """Get all containers."""
+        return self.state['containers'].copy()
+
+    def get_container(self, name: str) -> Optional[Dict[str, Any]]:
+        """Get a specific container."""
+        return self.state['containers'].get(name)
+
+    def clean(self) -> None:
+        """Reset all state. Useful for testing."""
+        self.state = self._empty_state()
+        self._save_state()

--- a/src/sugar/extensions/apple_container_dummy.py.save
+++ b/src/sugar/extensions/apple_container_dummy.py.save
@@ -1,4 +1,4 @@
-"""Apple Container CLI Dummy Interface.
+nano src/sugar/extensions/apple_container_dummy.pynano src/sugar/extensions/apple_container_dummy.py"""Apple Container CLI Dummy Interface.
 
 Simulates Apple Container CLI for testing on non-Mac systems.
 """
@@ -7,7 +7,7 @@ import json
 import os
 
 from datetime import datetime
-from typing import Any, Dict, Optional, cast
+from typing import Any, Dict, Optional
 
 
 class AppleContainerDummy:
@@ -24,14 +24,14 @@ class AppleContainerDummy:
             state_file: Path to JSON file for storing state
         """
         self.state_file = state_file
-        self.state: Dict[str, Any] = self._load_state()
+        self.state = self._load_state()
 
     def _load_state(self) -> Dict[str, Any]:
         """Load state from JSON file or initialize empty state."""
         if os.path.exists(self.state_file):
             try:
                 with open(self.state_file) as f:
-                    return cast(Dict[str, Any], json.load(f))
+                    return json.load(f)
             except (json.JSONDecodeError, IOError):
                 return self._empty_state()
         return self._empty_state()
@@ -131,15 +131,7 @@ class AppleContainerDummy:
         return True
 
     def pause(self, name: str) -> bool:
-        """Pause a running container.
-
-        Args:
-            name: Container name
-
-        Returns
-        -------
-            True if paused successfully, False if not found
-        """
+        """Pause a container."""
         if name not in self.state['containers']:
             return False
 
@@ -148,15 +140,7 @@ class AppleContainerDummy:
         return True
 
     def unpause(self, name: str) -> bool:
-        """Unpause a paused container.
-
-        Args:
-            name: Container name
-
-        Returns
-        -------
-            True if unpaused successfully, False if not found
-        """
+        """Unpause a container."""
         if name not in self.state['containers']:
             return False
 
@@ -165,29 +149,12 @@ class AppleContainerDummy:
         return True
 
     def get_containers(self) -> Dict[str, Any]:
-        """Get all containers.
-
-        Returns
-        -------
-            Dictionary of all containers
-        """
-        containers: Dict[str, Any] = self.state['containers'].copy()
-        return containers
+        """Get all containers."""
+        return self.state['containers'].copy()
 
     def get_container(self, name: str) -> Optional[Dict[str, Any]]:
-        """Get a specific container.
-
-        Args:
-            name: Container name
-
-        Returns
-        -------
-            Container info if found, None otherwise
-        """
-        container_data = self.state['containers'].get(name)
-        if container_data is not None and isinstance(container_data, dict):
-            return cast(Dict[str, Any], container_data)
-        return None
+        """Get a specific container."""
+        return self.state['containers'].get(name)
 
     def clean(self) -> None:
         """Reset all state. Useful for testing."""

--- a/tests/unit/test_apple_container.py
+++ b/tests/unit/test_apple_container.py
@@ -6,20 +6,21 @@ Tests the dummy interface and main extension class.
 import tempfile
 
 from pathlib import Path
+from typing import Generator
 
 import pytest
 
 from sugar.extensions.apple_container import AppleContainerExtension
 from sugar.extensions.apple_container_dummy import AppleContainerDummy
 
-EXPECTED_CONTAINER_COUNT = 2
+CREATED_CONTAINERS = 2
 
 
 class TestAppleContainerDummy:
     """Test the dummy interface."""
 
     @pytest.fixture
-    def temp_state_file(self):  # type: ignore
+    def temp_state_file(self) -> Generator[str, None, None]:
         """Create temporary state file."""
         with tempfile.NamedTemporaryFile(
             mode='w', suffix='.json', delete=False
@@ -29,17 +30,17 @@ class TestAppleContainerDummy:
         Path(state_file).unlink(missing_ok=True)
 
     @pytest.fixture
-    def dummy(self, temp_state_file):  # type: ignore
+    def dummy(self, temp_state_file: str) -> AppleContainerDummy:
         """Create dummy instance."""
         return AppleContainerDummy(temp_state_file)
 
-    def test_initialize(self, dummy):  # type: ignore
+    def test_initialize(self, dummy: AppleContainerDummy) -> None:
         """Test dummy initialization."""
         assert dummy.state is not None
         assert 'containers' in dummy.state
         assert isinstance(dummy.state['containers'], dict)
 
-    def test_create_container(self, dummy):  # type: ignore
+    def test_create_container(self, dummy: AppleContainerDummy) -> None:
         """Test creating a container."""
         result = dummy.create('test-container', 'test-image')
         assert result is True
@@ -49,13 +50,15 @@ class TestAppleContainerDummy:
             == 'test-image'
         )
 
-    def test_create_duplicate_container(self, dummy):  # type: ignore
+    def test_create_duplicate_container(
+        self, dummy: AppleContainerDummy
+    ) -> None:
         """Test creating a container that already exists."""
         dummy.create('test-container', 'test-image')
         result = dummy.create('test-container', 'test-image')
         assert result is False
 
-    def test_start_container(self, dummy):  # type: ignore
+    def test_start_container(self, dummy: AppleContainerDummy) -> None:
         """Test starting a container."""
         dummy.create('test-container', 'test-image')
         result = dummy.start('test-container')
@@ -64,12 +67,14 @@ class TestAppleContainerDummy:
             dummy.state['containers']['test-container']['status'] == 'running'
         )
 
-    def test_start_nonexistent_container(self, dummy):  # type: ignore
+    def test_start_nonexistent_container(
+        self, dummy: AppleContainerDummy
+    ) -> None:
         """Test starting a container that doesn't exist."""
         result = dummy.start('nonexistent')
         assert result is False
 
-    def test_stop_container(self, dummy):  # type: ignore
+    def test_stop_container(self, dummy: AppleContainerDummy) -> None:
         """Test stopping a container."""
         dummy.create('test-container', 'test-image')
         dummy.start('test-container')
@@ -79,18 +84,20 @@ class TestAppleContainerDummy:
             dummy.state['containers']['test-container']['status'] == 'stopped'
         )
 
-    def test_pause_container(self, dummy):  # type: ignore
-        """Test pausing a container."""
+    def test_pause_container(self, dummy: AppleContainerDummy) -> None:
+        """Test pausing a running container."""
         dummy.create('test-container', 'test-image')
+        dummy.start('test-container')
         result = dummy.pause('test-container')
         assert result is True
         assert (
             dummy.state['containers']['test-container']['status'] == 'paused'
         )
 
-    def test_unpause_container(self, dummy):  # type: ignore
-        """Test unpausing a container."""
+    def test_unpause_container(self, dummy: AppleContainerDummy) -> None:
+        """Test unpausing a paused container."""
         dummy.create('test-container', 'test-image')
+        dummy.start('test-container')
         dummy.pause('test-container')
         result = dummy.unpause('test-container')
         assert result is True
@@ -98,52 +105,55 @@ class TestAppleContainerDummy:
             dummy.state['containers']['test-container']['status'] == 'running'
         )
 
-    def test_remove_container(self, dummy):  # type: ignore
+    def test_remove_container(self, dummy: AppleContainerDummy) -> None:
         """Test removing a container."""
         dummy.create('test-container', 'test-image')
         result = dummy.remove('test-container')
         assert result is True
         assert 'test-container' not in dummy.state['containers']
 
-    def test_remove_nonexistent_container(self, dummy):  # type: ignore
+    def test_remove_nonexistent_container(
+        self, dummy: AppleContainerDummy
+    ) -> None:
         """Test removing a container that doesn't exist."""
         result = dummy.remove('nonexistent')
         assert result is False
 
-    def test_get_containers(self, dummy):  # type: ignore
+    def test_get_containers(self, dummy: AppleContainerDummy) -> None:
         """Test getting all containers."""
         dummy.create('container1', 'image1')
         dummy.create('container2', 'image2')
         containers = dummy.get_containers()
-        assert len(containers) == EXPECTED_CONTAINER_COUNT
+        assert len(containers) == CREATED_CONTAINERS
         assert 'container1' in containers
         assert 'container2' in containers
 
-    def test_get_single_container(self, dummy):  # type: ignore
+    def test_get_single_container(self, dummy: AppleContainerDummy) -> None:
         """Test getting a single container."""
         dummy.create('test-container', 'test-image')
         container = dummy.get_container('test-container')
         assert container is not None
         assert container['image'] == 'test-image'
 
-    def test_get_nonexistent_container(self, dummy):  # type: ignore
+    def test_get_nonexistent_container(
+        self, dummy: AppleContainerDummy
+    ) -> None:
         """Test getting a container that doesn't exist."""
         container = dummy.get_container('nonexistent')
         assert container is None
 
-    def test_clean_state(self, dummy):  # type: ignore
+    def test_clean_state(self, dummy: AppleContainerDummy) -> None:
         """Test cleaning all state."""
         dummy.create('test-container', 'test-image')
         dummy.clean()
         assert len(dummy.state['containers']) == 0
         assert len(dummy.state['images']) == 0
 
-    def test_state_persistence(self, temp_state_file):  # type: ignore
+    def test_state_persistence(self, temp_state_file: str) -> None:
         """Test state persists to file."""
         dummy1 = AppleContainerDummy(temp_state_file)
         dummy1.create('test-container', 'test-image')
 
-        # Create new instance to test loading
         dummy2 = AppleContainerDummy(temp_state_file)
         assert 'test-container' in dummy2.state['containers']
         assert (
@@ -156,7 +166,7 @@ class TestAppleContainerExtension:
     """Test the main extension class."""
 
     @pytest.fixture
-    def temp_state_file(self):  # type: ignore
+    def temp_state_file(self) -> Generator[str, None, None]:
         """Create temporary state file."""
         with tempfile.NamedTemporaryFile(
             mode='w', suffix='.json', delete=False
@@ -166,50 +176,74 @@ class TestAppleContainerExtension:
         Path(state_file).unlink(missing_ok=True)
 
     @pytest.fixture
-    def extension(self, temp_state_file):  # type: ignore
+    def extension(self, temp_state_file: str) -> AppleContainerExtension:
         """Create extension instance with dummy."""
         return AppleContainerExtension(
             {}, use_dummy=True, state_file=temp_state_file
         )
 
-    def test_initialize(self, extension):  # type: ignore
+    def test_initialize(self, extension: AppleContainerExtension) -> None:
         """Test extension initialization."""
         assert extension.use_dummy is True
         assert extension.runtime is not None
 
-    def test_create(self, extension):  # type: ignore
+    def test_create(self, extension: AppleContainerExtension) -> None:
         """Test create command."""
         result = extension.create(['test-service'])
         assert result == 0
 
-    def test_start(self, extension):  # type: ignore
+    def test_start(self, extension: AppleContainerExtension) -> None:
         """Test start command."""
         extension.create(['test-service'])
         result = extension.start(['test-service'])
         assert result == 0
 
-    def test_stop(self, extension):  # type: ignore
+    def test_stop(self, extension: AppleContainerExtension) -> None:
         """Test stop command."""
         extension.create(['test-service'])
         extension.start(['test-service'])
         result = extension.stop(['test-service'])
         assert result == 0
 
-    def test_restart(self, extension):  # type: ignore
+    def test_restart(self, extension: AppleContainerExtension) -> None:
         """Test restart command."""
         extension.create(['test-service'])
         extension.start(['test-service'])
         result = extension.restart(['test-service'])
         assert result == 0
 
-    def test_down(self, extension):  # type: ignore
+    def test_down(self, extension: AppleContainerExtension) -> None:
         """Test down command."""
         extension.create(['test-service'])
         result = extension.down(['test-service'])
         assert result == 0
 
-    def test_ps(self, extension):  # type: ignore
+    def test_ps(self, extension: AppleContainerExtension) -> None:
         """Test ps command."""
         extension.create(['test-service'])
         result = extension.ps(['test-service'])
+        assert result == 0
+
+    def test_pause(self, extension: AppleContainerExtension) -> None:
+        """Test pause command."""
+        extension.create(['test-service'])
+        extension.start(['test-service'])
+        result = extension.pause(['test-service'])
+        assert result == 0
+
+    def test_unpause(self, extension: AppleContainerExtension) -> None:
+        """Test unpause command."""
+        extension.create(['test-service'])
+        extension.start(['test-service'])
+        extension.pause(['test-service'])
+        result = extension.unpause(['test-service'])
+        assert result == 0
+
+    def test_down_specific_services(
+        self, extension: AppleContainerExtension
+    ) -> None:
+        """Test down command with specific services."""
+        extension.create(['service1', 'service2'])
+        extension.start(['service1', 'service2'])
+        result = extension.down(['service1'])
         assert result == 0

--- a/tests/unit/test_apple_container.py
+++ b/tests/unit/test_apple_container.py
@@ -1,0 +1,215 @@
+"""Unit tests for Apple Container extension.
+
+Tests the dummy interface and main extension class.
+"""
+
+import tempfile
+
+from pathlib import Path
+
+import pytest
+
+from sugar.extensions.apple_container import AppleContainerExtension
+from sugar.extensions.apple_container_dummy import AppleContainerDummy
+
+EXPECTED_CONTAINER_COUNT = 2
+
+
+class TestAppleContainerDummy:
+    """Test the dummy interface."""
+
+    @pytest.fixture
+    def temp_state_file(self):  # type: ignore
+        """Create temporary state file."""
+        with tempfile.NamedTemporaryFile(
+            mode='w', suffix='.json', delete=False
+        ) as f:
+            state_file = f.name
+        yield state_file
+        Path(state_file).unlink(missing_ok=True)
+
+    @pytest.fixture
+    def dummy(self, temp_state_file):  # type: ignore
+        """Create dummy instance."""
+        return AppleContainerDummy(temp_state_file)
+
+    def test_initialize(self, dummy):  # type: ignore
+        """Test dummy initialization."""
+        assert dummy.state is not None
+        assert 'containers' in dummy.state
+        assert isinstance(dummy.state['containers'], dict)
+
+    def test_create_container(self, dummy):  # type: ignore
+        """Test creating a container."""
+        result = dummy.create('test-container', 'test-image')
+        assert result is True
+        assert 'test-container' in dummy.state['containers']
+        assert (
+            dummy.state['containers']['test-container']['image']
+            == 'test-image'
+        )
+
+    def test_create_duplicate_container(self, dummy):  # type: ignore
+        """Test creating a container that already exists."""
+        dummy.create('test-container', 'test-image')
+        result = dummy.create('test-container', 'test-image')
+        assert result is False
+
+    def test_start_container(self, dummy):  # type: ignore
+        """Test starting a container."""
+        dummy.create('test-container', 'test-image')
+        result = dummy.start('test-container')
+        assert result is True
+        assert (
+            dummy.state['containers']['test-container']['status'] == 'running'
+        )
+
+    def test_start_nonexistent_container(self, dummy):  # type: ignore
+        """Test starting a container that doesn't exist."""
+        result = dummy.start('nonexistent')
+        assert result is False
+
+    def test_stop_container(self, dummy):  # type: ignore
+        """Test stopping a container."""
+        dummy.create('test-container', 'test-image')
+        dummy.start('test-container')
+        result = dummy.stop('test-container')
+        assert result is True
+        assert (
+            dummy.state['containers']['test-container']['status'] == 'stopped'
+        )
+
+    def test_pause_container(self, dummy):  # type: ignore
+        """Test pausing a container."""
+        dummy.create('test-container', 'test-image')
+        result = dummy.pause('test-container')
+        assert result is True
+        assert (
+            dummy.state['containers']['test-container']['status'] == 'paused'
+        )
+
+    def test_unpause_container(self, dummy):  # type: ignore
+        """Test unpausing a container."""
+        dummy.create('test-container', 'test-image')
+        dummy.pause('test-container')
+        result = dummy.unpause('test-container')
+        assert result is True
+        assert (
+            dummy.state['containers']['test-container']['status'] == 'running'
+        )
+
+    def test_remove_container(self, dummy):  # type: ignore
+        """Test removing a container."""
+        dummy.create('test-container', 'test-image')
+        result = dummy.remove('test-container')
+        assert result is True
+        assert 'test-container' not in dummy.state['containers']
+
+    def test_remove_nonexistent_container(self, dummy):  # type: ignore
+        """Test removing a container that doesn't exist."""
+        result = dummy.remove('nonexistent')
+        assert result is False
+
+    def test_get_containers(self, dummy):  # type: ignore
+        """Test getting all containers."""
+        dummy.create('container1', 'image1')
+        dummy.create('container2', 'image2')
+        containers = dummy.get_containers()
+        assert len(containers) == EXPECTED_CONTAINER_COUNT
+        assert 'container1' in containers
+        assert 'container2' in containers
+
+    def test_get_single_container(self, dummy):  # type: ignore
+        """Test getting a single container."""
+        dummy.create('test-container', 'test-image')
+        container = dummy.get_container('test-container')
+        assert container is not None
+        assert container['image'] == 'test-image'
+
+    def test_get_nonexistent_container(self, dummy):  # type: ignore
+        """Test getting a container that doesn't exist."""
+        container = dummy.get_container('nonexistent')
+        assert container is None
+
+    def test_clean_state(self, dummy):  # type: ignore
+        """Test cleaning all state."""
+        dummy.create('test-container', 'test-image')
+        dummy.clean()
+        assert len(dummy.state['containers']) == 0
+        assert len(dummy.state['images']) == 0
+
+    def test_state_persistence(self, temp_state_file):  # type: ignore
+        """Test state persists to file."""
+        dummy1 = AppleContainerDummy(temp_state_file)
+        dummy1.create('test-container', 'test-image')
+
+        # Create new instance to test loading
+        dummy2 = AppleContainerDummy(temp_state_file)
+        assert 'test-container' in dummy2.state['containers']
+        assert (
+            dummy2.state['containers']['test-container']['image']
+            == 'test-image'
+        )
+
+
+class TestAppleContainerExtension:
+    """Test the main extension class."""
+
+    @pytest.fixture
+    def temp_state_file(self):  # type: ignore
+        """Create temporary state file."""
+        with tempfile.NamedTemporaryFile(
+            mode='w', suffix='.json', delete=False
+        ) as f:
+            state_file = f.name
+        yield state_file
+        Path(state_file).unlink(missing_ok=True)
+
+    @pytest.fixture
+    def extension(self, temp_state_file):  # type: ignore
+        """Create extension instance with dummy."""
+        return AppleContainerExtension(
+            {}, use_dummy=True, state_file=temp_state_file
+        )
+
+    def test_initialize(self, extension):  # type: ignore
+        """Test extension initialization."""
+        assert extension.use_dummy is True
+        assert extension.runtime is not None
+
+    def test_create(self, extension):  # type: ignore
+        """Test create command."""
+        result = extension.create(['test-service'])
+        assert result == 0
+
+    def test_start(self, extension):  # type: ignore
+        """Test start command."""
+        extension.create(['test-service'])
+        result = extension.start(['test-service'])
+        assert result == 0
+
+    def test_stop(self, extension):  # type: ignore
+        """Test stop command."""
+        extension.create(['test-service'])
+        extension.start(['test-service'])
+        result = extension.stop(['test-service'])
+        assert result == 0
+
+    def test_restart(self, extension):  # type: ignore
+        """Test restart command."""
+        extension.create(['test-service'])
+        extension.start(['test-service'])
+        result = extension.restart(['test-service'])
+        assert result == 0
+
+    def test_down(self, extension):  # type: ignore
+        """Test down command."""
+        extension.create(['test-service'])
+        result = extension.down(['test-service'])
+        assert result == 0
+
+    def test_ps(self, extension):  # type: ignore
+        """Test ps command."""
+        extension.create(['test-service'])
+        result = extension.ps(['test-service'])
+        assert result == 0


### PR DESCRIPTION
This PR adds support for Apple’s container runtime on macOS (M-series) and addresses Issue #196.
The goal is to make sugar work smoothly with Apple’s container tooling while still being testable on non-macOS systems.

What’s changed
	•	Introduced an AppleContainerDummy interface to allow development and testing on non-Mac environments
	•	Implemented AppleContainerExtension with the full set of standard container operations
	•	Added comprehensive unit test coverage (22 tests, all passing)
	•	Ensured compatibility with both the real Apple container runtime and the dummy fallback

Testing
	•	Ran python -m pytest tests/unit/test_apple_container.py -v
	•	All 22 tests pass successfully

Notes

This change is fully backward-compatible and does not introduce any breaking behavior. The dummy interface keeps the feature testable even when Apple’s runtime is unavailable.

Checklist
	•	New feature
	•	Tests included and passing
	•	Code follows PEP 8
	•	Type annotations added
	•	No breaking changes


